### PR TITLE
Fix the samplefile

### DIFF
--- a/sample-containerfile/Containerfile
+++ b/sample-containerfile/Containerfile
@@ -5,6 +5,10 @@ MAINTAINER Sander <mail@sandervanvugt.nl>
 COPY ./sander.repo /etc/yum.repos.d/
 
 # Install cool software
+RUN sed -i s/#baseurl/baseurl/ /etc/yum.repos.d/CentOS-Base.repo && \
+    sed -i s/mirrorlist.centos.org/vault.centos.org/ /etc/yum.repos.d/CentOS-Base.repo && \
+    sed -i s/mirror.centos.org/vault.centos.org/ /etc/yum.repos.d/CentOS-Base.repo && \
+    yum clean all
 RUN 	yum -y update 
 RUN	yum -y install bash nmap iproute 
 RUN	yum clean all


### PR DESCRIPTION
This doesn't work correctly due to the EOL of CentOS 7. To be precise, due to removing the version 7 from the mirrors and archiving it into vault.

This will mess up the number of steps in the RUN commands. Tho, looks like it's a necessary evil.